### PR TITLE
Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
 Run nix as user in a lightweight chrooted container.
 
 ```
-$ mkdir $ROOT
-$ nix-user-chroot $ROOT bash
+$ mkdir -m 0755 ~/nix && chown $(whoami) ~/nix
+$ nix-user-chroot ~/.nix sh
 $ download and extract latest nix binary tarball
-$ mkdir -m 0755 /nix && chown $(whoami) /nix
-$ mkdir -p /nix/var/nix/profiles/per-user/luca
 $ nix-*-linux/install
 ```
 

--- a/main.c
+++ b/main.c
@@ -96,6 +96,13 @@ path_buf, path_buf2, strerror(errno));
         }
     }
 
+    // fixes issue #1 where writing to /proc/self/gid_map fails
+    // see user_namespaces(7) for more documentation
+    int fd_setgroups = open("/proc/self/setgroups", O_WRONLY);
+    if (fd_setgroups > 0) {
+        write(fd_setgroups, "deny", 4);
+    }
+
     // map the original uid/gid in the new ns
     snprintf(map_buf, sizeof(map_buf), "%d %d 1", uid, uid);
     update_map(map_buf, "/proc/self/uid_map");

--- a/main.c
+++ b/main.c
@@ -17,7 +17,7 @@
 #define err_exit(msg) { perror(msg); exit(EXIT_FAILURE); }
 
 static void usage(char *pname) {
-    fprintf(stderr, "Usage: %s <rootdir> <command>\n", pname);
+    fprintf(stderr, "Usage: %s <command>\n", pname);
 
     exit(EXIT_FAILURE);
 }
@@ -44,11 +44,12 @@ int main(int argc, char *argv[]) {
     char path_buf2[PATH_MAX];
     char cwd[PATH_MAX];
 
-    if (argc < 3) {
+    if (argc < 2) {
         usage(argv[0]);
     }
 
-    char *rootdir = realpath(argv[1], NULL);
+    char template[] = "/tmp/nixXXXXXX";
+    char *rootdir = mkdtemp(template);
     if (!rootdir) {
         err_exit("realpath");
     }
@@ -118,6 +119,6 @@ int main(int argc, char *argv[]) {
     // execute the command
 
     setenv("NIX_CONF_DIR", "/nix/etc/nix", 1);
-    execvp(argv[2], argv+2);
+    execvp(argv[1], argv+1);
     err_exit("execvp");
 }

--- a/main.c
+++ b/main.c
@@ -76,7 +76,7 @@ int main(int argc, char *argv[]) {
         snprintf(path_buf, sizeof(path_buf), "/%s", ent->d_name);
 
         struct stat statbuf;
-        if (lstat(path_buf, &statbuf) < 0) {
+        if (stat(path_buf, &statbuf) < 0) {
             fprintf(stderr, "Cannot stat %s: %s\n", path_buf, strerror(errno));
             continue;
         }


### PR DESCRIPTION
I've got a few different commits:
- 3ba9c54: fix for #1
- f1f9de0: some random cleanup fixes
- 949540a: follow symlinks when they are in / (mainly for when /bin/ is symlinked to /usr/bin/)
- a000e62: generate ROOT automatically, get rid of argument
- d2c803d: add a nixpath arg that will automatically link to /nix
- 58e8e85: update readme based on changes in d2c803d
