### PR TITLE
Use pivot_root instead of chroot

### DIFF
--- a/main.c
+++ b/main.c
@@ -141,8 +141,10 @@ int main(int argc, char *argv[]) {
     }
 
     // mount the store and hide the old root
-    if (mount(nixdir, "/nix", "none", MS_BIND | MS_REC, NULL) < 0) {
-        err_exit("mount(%s, /nix", nixdir);
+    // we fetch nixdir under the old root
+    snprintf(path_buf, sizeof(path_buf), "/nix/%s", nixdir);
+    if (mount(path_buf, "/nix", "none", MS_BIND | MS_REC, NULL) < 0) {
+        err_exit("mount --bind %s /nix", path_buf);
     }
 
     // fixes issue #1 where writing to /proc/self/gid_map fails

--- a/main.c
+++ b/main.c
@@ -100,7 +100,9 @@ int main(int argc, char *argv[]) {
     // keep / clean is to hide the directory with another mountpoint. Therefore
     // we pivot the old root to /nix. This is somewhat confusing, though.
     snprintf(path_buf, sizeof(path_buf), "%s/nix", rootdir);
-    mkdir(path_buf, 0); // the mode is irrelevant
+    if (mkdir(path_buf, 0) < 0) { // the mode is irrelevant
+        err_exit("mkdir(%s, 0)", path_buf);
+    }
 
     // pivot_root
     if (pivot_root(rootdir, path_buf) < 0) {
@@ -109,10 +111,10 @@ int main(int argc, char *argv[]) {
     chdir("/");
 
     // bind mount all / stuff into rootdir
-    // they are now available under /nix
+    // the orginal content of / now available under /nix
     DIR* d = opendir("/nix");
     if (!d) {
-        err_exit("open /");
+        err_exit("open /nix");
     }
 
     struct dirent *ent;


### PR DESCRIPTION
Using pivot_root instead of chroot enables the use of user namespaces inside nix-user-chroot:
before
```
$ nix-build --option sandbox true -E 'with import <nixpkgs> {}; stdenv.mkDerivation { name = "need-sandbox"; src=sl.src; buildScript = "echo yay"; }'
these derivations will be built:
  /nix/store/hgqsrs11mhhzydahv8hr4q6ks7ljxn5g-need-sandbox.drv
error: cloning builder process: Operation not permitted
error: unable to start build process
```
After:
```
$ nix-build --option sandbox true -E 'with import <nixpkgs> {}; stdenv.mkDerivation { name = "need-sandbox"; buildCommand = "echo yay; touch $out"; }'
these derivations will be built:
  /nix/store/qpa0aj8ii9bv75wvy77xb1jgp14mpq94-need-sandbox.drv
building '/nix/store/qpa0aj8ii9bv75wvy77xb1jgp14mpq94-need-sandbox.drv'...
yay
/nix/store/fvdflsac743zh3f3q0s1zzba2348sliw-need-sandbox
```

The inspiration for using pivot_root is https://lkml.org/lkml/2018/10/15/628

One quirk is that creating a temporary directory, bind mounting everything inside and then pivot_root does not work (for an unknown reason). The bindmounted directories are empty after pivoting. So instead I go the other way around: pivot_root to an empty directory and then I use the mount point for the old root to repopulate the new one.
One detail is that I cannot unmount the old root. So I hide it with another. The only directory which is guaranteed to be in the new root is /nix, so I pivot the old root to /nix. This is a bit confusing when reading the code.